### PR TITLE
Updates to HTML builder to eliminate duplicate entries in github pages

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -32,6 +32,7 @@ the "Pull Request" build in the CI Panel
     :width: 650
     :alt: CircleCI Builds found in a Github Pull Request
 
+
 Go ahead and open the "Details" link for "Pull Request" build in another tab to inspect the CircleCI Build logs for
 this specific pull request.
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -32,7 +32,6 @@ the "Pull Request" build in the CI Panel
     :width: 650
     :alt: CircleCI Builds found in a Github Pull Request
 
-
 Go ahead and open the "Details" link for "Pull Request" build in another tab to inspect the CircleCI Build logs for
 this specific pull request.
 

--- a/nbcollection/ci/merge_artifacts/html_builder.py
+++ b/nbcollection/ci/merge_artifacts/html_builder.py
@@ -109,7 +109,6 @@ def extract_cells_from_html(filepath: str) -> None:
     cell_data = []
     # NGC4151_FeII_ContinuumFit
     for cell in soup.findAll('div', {'class': ['jp-Cell-inputWrapper']}):
-    #for cell in soup.findAll('div', {'class': ['jp-Cell', 'jp-Cell-inputWrapper']}):
         cell_data.append(str(cell))
 
     if len(cell_data) < 1:

--- a/nbcollection/ci/merge_artifacts/html_builder.py
+++ b/nbcollection/ci/merge_artifacts/html_builder.py
@@ -108,7 +108,8 @@ def extract_cells_from_html(filepath: str) -> None:
 
     cell_data = []
     # NGC4151_FeII_ContinuumFit
-    for cell in soup.findAll('div', {'class': ['jp-Cell', 'jp-Cell-inputWrapper']}):
+    for cell in soup.findAll('div', {'class': ['jp-Cell-inputWrapper']}):
+    #for cell in soup.findAll('div', {'class': ['jp-Cell', 'jp-Cell-inputWrapper']}):
         cell_data.append(str(cell))
 
     if len(cell_data) < 1:

--- a/nbcollection/ci/renderer/template/setup-env.sh
+++ b/nbcollection/ci/renderer/template/setup-env.sh
@@ -11,7 +11,6 @@ apt-get install -y git make build-essential libssl-dev zlib1g-dev libbz2-dev lib
 
 git clone https://github.com/spacetelescope/nbcollection nbcollection
 cd nbcollection
-git checkout fab2bce05cd24010a6c0f94e76bdfb83e9999096
 pip install -U pip setuptools
 pip install -r ci_requirements.txt
 python setup.py install


### PR DESCRIPTION
Removed an unnecessary tag from the html builder code that resulted in duplicate entries in the generated github pages. 
Removed a checkout of a specific branch when pulling the latest nbcollection from github.