### PR TITLE
make tox build docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     codestyle
     securityaudit
     pep517
+    docs
 
 requires =
     setuptools >= 30.3.0
@@ -19,11 +20,8 @@ description =
     run nbcollection_tests
 
 deps =
-    -rci_requirements.txt
+    -r ci_requirements.txt
     pytest
-    flake8
-    sphinx
-    sphinx_rtd_theme
     setuptools
 
 commands =
@@ -35,6 +33,7 @@ commands =
 changedir = docs
 description = check the links in the HTML docs
 extras = docs
+deps = sphinx
 commands =
     pip freeze
     sphinx-build -W -b linkcheck . _build/html
@@ -54,3 +53,13 @@ changedir = .
 description = security audit with bandit
 deps = bandit
 commands = bandit -r nbcollection -c .bandit.yaml
+
+[testenv:docs]
+description = build sphinx docs for nbcollection
+skip_install = true
+changedir = .
+deps = sphinx
+       sphinx_rtd_theme
+commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" --color -W -b html
+           python -c 'import pathlib; print("documentation available under file://\{0\}".format(pathlib.Path(r"{toxworkdir}") / "docs_out" / "index.html"))' 
+


### PR DESCRIPTION
This fixes the tox.ini file to allow for a doc build. 